### PR TITLE
Update amazon_product_review_scraper.py

### DIFF
--- a/amazon_product_review_scraper/amazon_product_review_scraper.py
+++ b/amazon_product_review_scraper/amazon_product_review_scraper.py
@@ -166,7 +166,8 @@ class amazon_product_review_scraper:
         proxies = []
         response = requests.get("https://sslproxies.org/")
         soup = BeautifulSoup(response.content, 'html.parser')
-        proxies_table = soup.find(id='proxylisttable')
+        # proxies_table = soup.find(id='proxylisttable')
+        proxies_table = soup.find(class_='table table-striped table-bordered')
         for row in proxies_table.tbody.find_all('tr'):
             proxies.append({
                 'ip':   row.find_all('td')[0].string,


### PR DESCRIPTION
the proxy generator function is not working as in the HTML they have removed the id tag of the tables, and when we try soup.find(id='proxylisttable') it returns None, so we need to parse as per the table class: soup.find(class_='table table-striped table-bordered'). Doing this returns all the proxy and the code works perfectly there after. 